### PR TITLE
Correction dropout

### DIFF
--- a/Laboratoire 4.ipynb
+++ b/Laboratoire 4.ipynb
@@ -349,8 +349,7 @@
     "        x = x.view(-1, 28*28)\n",
     "        out = F.relu(self.first_layer.forward(x))\n",
     "        for i, l in enumerate(self.layers):\n",
-    "            out = l.forward(out)\n",
-    "            out = F.relu(out)\n",
+    "            out = F.relu(layer(out))\n",
     "            if self.use_dropout and i < len(self.layers) - 1:\n",
     "                out = F.dropout(out, 0.4, training=self.training)\n",
     "        return self.output_layer.forward(out)"


### PR DESCRIPTION
L'utilisation de la méthode forward créé de la confusion. Plus clair de se limiter uniquement à l'appel du layer comme une fonction.