### PR TITLE
Remove num_layers from certain ConvNet class definitions

### DIFF
--- a/Laboratoire 5.ipynb
+++ b/Laboratoire 5.ipynb
@@ -404,7 +404,7 @@
    "outputs": [],
    "source": [
     "class ConvNet(nn.Module):\n",
-    "    def __init__(self, num_layers):\n",
+    "    def __init__(self):\n",
     "        super().__init__()\n",
     "        pass\n",
     "\n",
@@ -456,7 +456,7 @@
    "outputs": [],
    "source": [
     "class ConvNet(nn.Module):\n",
-    "    def __init__(self, num_layers):\n",
+    "    def __init__(self):\n",
     "        super().__init__()\n",
     "        pass\n",
     "\n",


### PR DESCRIPTION
`num_layers` argument in some ConvNet classes made it so it was impossible to call the class like intended.